### PR TITLE
Fix model selection in the state machine.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,4 @@
 {
-    "python.linting.pylintEnabled": false,
-    "python.linting.mypyEnabled": true,
-    "python.linting.enabled": false,
-    "python.linting.mypyArgs": [
-        "--follow-imports=silent",
-        "--show-column-numbers",
-        "--no-pretty",
-        "--show-error-codes"
-    ],
     "mypy.runUsingActiveInterpreter": true,
     "mypy.targets": [
         "rrosti", "tests"
@@ -39,7 +30,7 @@
         }
     ],
     "python.testing.pytestArgs": [
-        "rrosti", "tests"
+        "tests"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,


### PR DESCRIPTION
- The model was simply not propagated correctly in some cases.

- In addition, the logic was more complicated than I thought. If in a conditional action we define a model, probably the most sensible idea is that we want that model to be applied to the next LLM call, no matter what (and no matter which agent executes that call). Implement this by adding a model override field in the StateMachineRunner class.

- Previously the model used to analyze a message sent by another agent was a field in the Message. Now, after some analysis, there's nothing particularly magical about sending messages (although it's there where the behavior is arguably the most surprising, the model used to parse a message defined by the send action in the other agent). So remove this field.